### PR TITLE
Incubating support for executable JARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ jruby-gradle-jar-plugin
 Plugin for creating JRuby-based java archives
 
 
-## Compatilibity
+## Compatibility
 
 This plugin requires Gradle 2.0 or better.
 
@@ -48,14 +48,8 @@ jar {
     // Can be called more than once for additional directories
     gemDir '/path/to/my/gemDir'
     
-    // Make the JAR executable and use the default main class
-    defaultMainClass()
-    
-    // Make the JAR executable by supplying your own main class
-    mainClass 'my.own.main.'
-    
-    // Equivalent to calling defaultGems() and defaultMainClass()
-    defaults 'gem, 'mainClass'
+    // Equivalent to calling defaultGems()
+    defaults 'gem'
         
   }
   
@@ -72,8 +66,35 @@ task myJar (type :Jar) {
 
 ```
 
+## Executable JARs
+
+Please note that executable JARs are still an incubating feature. At this point appropriate libs will be copied
+to the `META-INF/lib` directory, but a working `init.rb` is not available. It is still the responsibility of the
+the user to craft an appropriate `init.rb` and copy it to `META-INF` via the provided the [metaInf {}](http://www.gradle.org/docs/current/dsl/org.gradle.api.tasks.bundling.Jar.html) closure.
+ 
+ ```groovy
+ jar {
+   jruby {
+   
+     // Make the JAR executable and use the default main class
+     defaultMainClass()
+     
+     // Make the JAR executable by supplying your own main class
+     mainClass 'my.own.main.'
+     
+     // Equivalent to calling defaultMainClass()
+     defaults 'mainClass'
+     
+     // Adds dependencies from this configuration into `META-INF/lib`
+     // If none are specified, the plugin will default to 'jrubyJar','compile' & 'runtime'
+     configurations 'myConfig'    
+   }   
+ }
+```
+
 Using the default main class method `defaultMainClass()` will include class files from 
 [warbler-bootstrap](https://github.com/jruby-gradle/warbler-bootstrap) 
+
 
 ## Controlling the version of warbler-bootstrap
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 group = 'com.github.jruby-gradle'
-version = '0.1.0'
+version = '0.1.1'
 
 if (System.env.RELEASE != '1') {
     version = "${version}-SNAPSHOT"
@@ -28,12 +28,22 @@ configurations {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.github.jruby-gradle:jruby-gradle-plugin:0.1.2'
+    compile 'com.github.jruby-gradle:jruby-gradle-plugin:0.1.2+'
 
     testCompile ("org.spockframework:spock-core:0.7-groovy-${gradle.gradleVersion.startsWith('1.')?'1.8':'2.0'}") {
         exclude module : 'groovy-all'
     }
-    testWarbler group: 'com.github.jruby-gradle', name: 'warbler-bootstrap', version: '0.1.+'
+
+    // For the testWarbler tests I am locking the versions, instead of a open version, as it makes
+    // unit testing easier, This does not affect the final artifact.
+    // If you change values here, you need to update JRubyJarPluginSpec as well.
+    testWarbler 'com.github.jruby-gradle:warbler-bootstrap:0.1.0'
+    testWarbler ('org.jruby:jruby-complete:1.7.15') {
+        transitive = false
+    }
+    testWarbler ("org.spockframework:spock-core:0.7-groovy-2.0") {
+        transitive = false
+    }
 
 }
 

--- a/src/main/groovy/com/github/jrubygradle/jar/JRubyJarPlugin.groovy
+++ b/src/main/groovy/com/github/jrubygradle/jar/JRubyJarPlugin.groovy
@@ -15,6 +15,7 @@ class JRubyJarPlugin implements Plugin<Project> {
 
         project.apply plugin : 'com.github.jruby-gradle.base'
         project.configurations.maybeCreate('jrubyEmbeds')
+        project.configurations.maybeCreate('jrubyJar')
 
         // In order to update the testing cycle we need to tell unit tests where to
         // find GEMs. We are assuming that if someone includes this plugin, that they
@@ -58,6 +59,12 @@ class JRubyJarPlugin implements Plugin<Project> {
         project.afterEvaluate {
             WarblerBootstrap.addDependency(project)
             JRubyJarConfigurator.afterEvaluateAction(project)
+
+            project.dependencies {
+                jrubyJar group: 'org.jruby', name: 'jruby-complete', version: project.jruby.defaultVersion
+            }
+
+
         }
     }
 


### PR DESCRIPTION
Added support for copying JARs into `META-INF/lib` directory and updating the `Class-Path` attribute. Does not support `init.rb` yet. User is still reponsible for creating `init.rb` and adding to to `metaInf {}` closure.
