### PR TITLE
Added additional unit tests. .

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'com.jfrog.bintray'
 
+
 buildscript {
     repositories { jcenter() }
     dependencies { classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.5' }
@@ -9,6 +10,7 @@ buildscript {
 
 group = 'com.github.jruby-gradle'
 version = '0.1.1'
+archivesBaseName = 'jruby-gradle-jar-plugin'
 
 if (System.env.RELEASE != '1') {
     version = "${version}-SNAPSHOT"

--- a/src/main/groovy/com/github/jrubygradle/jar/JRubyJarConfigurator.groovy
+++ b/src/main/groovy/com/github/jrubygradle/jar/JRubyJarConfigurator.groovy
@@ -112,7 +112,7 @@ class JRubyJarConfigurator {
      */
     @Incubating
     void configuration(String name) {
-        this.configurations.add(archive.project.configurations.getByName(name))
+        this.configuration(archive.project.configurations.getByName(name))
     }
 
     /** Adds a configuration to the list of dependencies that will be packed when creating an executable jar
@@ -122,6 +122,9 @@ class JRubyJarConfigurator {
      */
     @Incubating
     void configuration(Configuration config) {
+        if(this.configurations==null) {
+            this.configurations = []
+        }
         this.configurations.add(config)
     }
 


### PR DESCRIPTION
- Fixed one bug surrounding `configuration` not being initialised
- Added unit tests for a number of scenarios around using `configuration`.
- Explicitly set the `archivesBaseName`, so that name of project directory does not affect it.
